### PR TITLE
Change cluster_id to cluster_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Cluster ID of the AWS EKS cluster for which kubeconfig needs to be generated | `string` | n/a | yes |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_name) | Cluster name of the AWS EKS cluster for which kubeconfig needs to be generated | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS EKS Kubeconfig Terraform module
 
-Terraform module which returns kubeconfig based on Ephemeral token for the cluster in question using cluster_id as an input.
+Terraform module which returns kubeconfig based on Ephemeral token for the cluster in question using cluster_name as an input.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_name) | Cluster name of the AWS EKS cluster for which kubeconfig needs to be generated | `string` | n/a | yes |
+| <a name="input_cluster_id"></a> [cluster\_name](#input\_cluster\_name) | Cluster name of the AWS EKS cluster for which kubeconfig needs to be generated | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 data "aws_eks_cluster" "this" {
-  name = var.cluster_id
+  name = var.cluster_name
 }
 
 data "aws_eks_cluster_auth" "ephemeral" {
-  name = var.cluster_id
+  name = var.cluster_name
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "cluster_id" {
+variable "cluster_name" {
   type        = string
-  description = "Cluster ID of the AWS EKS cluster for which kubeconfig needs to be generated"
+  description = "Cluster name of the AWS EKS cluster for which kubeconfig needs to be generated"
 }


### PR DESCRIPTION
I would use cluster_name variable instead of cluster_id as it passed in data 'aws_eks_cluster' because it potentially may confuse user what exactly it needed to be passed as a "id".